### PR TITLE
Update to support Visual Studio 2019

### DIFF
--- a/Build/GlobalAssemblyInfo.cs
+++ b/Build/GlobalAssemblyInfo.cs
@@ -12,5 +12,5 @@
 [assembly: AssemblyConfiguration("Release")]
 #endif
 
-[assembly: AssemblyVersion("1.6.*")]
-[assembly: AssemblyFileVersion("1.6")]
+[assembly: AssemblyVersion("1.7.*")]
+[assembly: AssemblyFileVersion("1.7")]

--- a/Tests/TestsBase/Stubs/TextBufferStub.cs
+++ b/Tests/TestsBase/Stubs/TextBufferStub.cs
@@ -100,6 +100,7 @@ namespace Balakin.VSOutputEnhancer.Tests.Stubs
             get { throw new NotImplementedException(); }
         }
 
+#pragma warning disable CS0067
         public event EventHandler<SnapshotSpanEventArgs> ReadOnlyRegionsChanged;
         public event EventHandler<TextContentChangedEventArgs> Changed;
         public event EventHandler<TextContentChangedEventArgs> ChangedLowPriority;
@@ -107,5 +108,6 @@ namespace Balakin.VSOutputEnhancer.Tests.Stubs
         public event EventHandler<TextContentChangingEventArgs> Changing;
         public event EventHandler PostChanged;
         public event EventHandler<ContentTypeChangedEventArgs> ContentTypeChanged;
+#pragma warning restore CS0067
     }
 }

--- a/VsixPackage/VsixPackage.csproj
+++ b/VsixPackage/VsixPackage.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.0.26109-RC3\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.26109-RC3\build\Microsoft.VSSDK.BuildTools.props')" />
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -26,6 +26,9 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -112,11 +115,11 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.26109-RC3\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.0.26109-RC3\build\Microsoft.VSSDK.BuildTools.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.26109-RC3\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.0.26109-RC3\build\Microsoft.VSSDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.0.26109-RC3\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.0.26109-RC3\build\Microsoft.VSSDK.BuildTools.targets')" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.9.3032\build\Microsoft.VSSDK.BuildTools.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/VsixPackage/packages.config
+++ b/VsixPackage/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26109-RC3" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.9.3032" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/VsixPackage/source.extension.vsixmanifest
+++ b/VsixPackage/source.extension.vsixmanifest
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="VSOutputEnhancer.Nikolay Balakin.a06be4c3-f97e-425c-8a0d-bdef08ac2abb" Version="1.6" Language="en-US" Publisher="Nikolay Balakin" />
-    <DisplayName>Output enhancer</DisplayName>
-    <Description xml:space="preserve">Extension to add colors to Visual Studio output window.</Description>
-    <License>License.txt</License>
-    <Icon>Icon.png</Icon>
-    <PreviewImage>Preview.png</PreviewImage>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[11.0,16.0)" />
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,16.0)" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="VSOutputEnhancer" Path="|VSOutputEnhancer|" />
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.25914.00,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
+    <Metadata>
+        <Identity Id="VSOutputEnhancer.Nikolay Balakin.a06be4c3-f97e-425c-8a0d-bdef08ac2abb" Version="1.7" Language="en-US" Publisher="Nikolay Balakin" />
+        <DisplayName>Output enhancer</DisplayName>
+        <Description xml:space="preserve">Extension to add colors to Visual Studio output window.</Description>
+        <License>License.txt</License>
+        <Icon>Icon.png</Icon>
+        <PreviewImage>Preview.png</PreviewImage>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[11.0,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,17.0)" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="VSOutputEnhancer" Path="|VSOutputEnhancer|" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.25914.00,17.0)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Fixes #19 

Adds support for VS 2019, tested by installing into 2017 and 2019. Also incremented the version so it is ready for the next release.

![image](https://user-images.githubusercontent.com/493828/49753311-f9b1e980-fc80-11e8-8aea-3e82beb26e5d.png)

![image](https://user-images.githubusercontent.com/493828/49753326-02a2bb00-fc81-11e8-8a7d-9a954df9b3c7.png)
